### PR TITLE
FIX NODE CRITICAL VULNERABILITY:

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -14,7 +14,7 @@ ENV VOLTA_HOME "/home/node/.volta"
 ENV PATH "$VOLTA_HOME/bin:$PATH"
 RUN curl https://get.volta.sh | bash
 
-RUN volta install node@18.12.0
+RUN volta install node@18.17.1
 
 RUN npm install -g @nestjs/cli
 RUN npm install -g pm2

--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -16,7 +16,7 @@ ENV PATH "$VOLTA_HOME/bin:$PATH"
 RUN curl https://get.volta.sh | bash
 
 
-RUN volta install node@18.12.0
+RUN volta install node@18.17.1
 
 RUN npm install -g vite
 RUN npm install -g eslint


### PR DESCRIPTION
close #44 

Our git history was having two version for the docker file, 
The first Dockerfile was installing node into regular ways,
@Elena-Lou suggested installing volta for faster build of the image. 
Was great because we having less vulnerability !
`version_debian : 7 Critical | 25 Hight | 29 Medium`
`version_volta : 1 Critical | 10 Hight | 11 Medium`

This dockerfile is quite similar except we update node version node@18.12.0 to 18.17.1 that permit to avoid the Critical vulnerability (recently appears)
The dockerfile's is on dockerhub repository, you can check evolution of dockerfile security [here](https://hub.docker.com/repository/docker/alexrdc/back_transcendence/general)

image tag of previous : version_volta (was only checked on back dockerfile)

images tag for this fix : version_volta_back && version_volta_front

May create new fix in the future for other vulnerability.

